### PR TITLE
mmenu setup in functions.js

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1,8 +1,27 @@
-define(['jquery', 'core/theme-app', 'theme/js/bootstrap.min'],function($, App){
+define(['jquery', 'core/theme-app', 'theme/js/jquery.mmenu.all.min'],function($, App){
     
-	//See http://uncategorized-creations.com/app-kit/doc/#237-functions-js to 
-	//learn more about what you can do in this functions.js file.
+	App.on( 'info:app-ready', function(){
+		
+		$( "#menu" ).mmenu( 
+			{
+				extensions: [ "theme-black" ],
+				navbar: false,
+				navbars: {
+					height: 4,
+					content: [
+						'<a href="4058426638" class="fa fa-phone"></a>',
+						'<img src="img/bmchs.png" />',
+						'<a href="https://mail.google.com/mail/u/0/#inbox " class="fa fa-envelope"></a>'
+					]
+				}
+			}
+		);
+
+		$("#menu").on("click","a",function(){
+			App.navigate($(this).attr('href'));
+		});
 	
+	});
 	
 	/**
 	 * Scroll to top each time a new screen is showed in the app.
@@ -13,7 +32,6 @@ define(['jquery', 'core/theme-app', 'theme/js/bootstrap.min'],function($, App){
 		scrollTop();
 	} );
 	
-	
 	/**
 	 * Get back to the top of the screen
 	 */
@@ -21,25 +39,4 @@ define(['jquery', 'core/theme-app', 'theme/js/bootstrap.min'],function($, App){
 		window.scrollTo( 0, 0 );
 	}
 	
-});
-
-define(['js/jquery.mmenu.all.min.js'],function(){
-	$(function() {
-				$("#menu")
-					.mmenu({
-		extensions 	: [ "theme-black" ],
-		navbar 		: false,
-		navbars		: {
-			height 	: 4,
-			content : [ 
-				'<a href="4058426638" class="fa fa-phone"></a>',
-				'<img src="img/bmchs.png" />',
-				'<a href="https://mail.google.com/mail/u/0/#inbox " class="fa fa-envelope"></a>'
-			]
-		}
-					});
-});
-
-define(['js/jquery-1.8.3.min.js'],function(){
-     //Nothing for now, this is just to include the js file in our theme.
 });


### PR DESCRIPTION
Hi, and thanks for using WP-AppKit!

Here are quick modifications to your functions.js file that allow the mmenu basic setting to work.

The problems I fixed:
- there can be only one "define" in functions.js
- JS files from your theme's js folder must be included with the "theme/" prefix and no trailling ".js" : "theme/js/jquery.mmenu.all.min"
- mmenu binding _$( "#menu" ).mmenu()_ has to be called after the app has finished rendering or the menu element is not in the DOM yet (the menu is rendered dynamically). To do so, I called _$( "#menu" ).mmenu()_ in the **info:app-ready** event.

Then I had the menu working.
But the links inside the menu did not trigger app navigation.
It seems that mmenu overrides the default click on links...
So I had to rebind clicks on menu links and navigate manually to the corresponding screen: https://github.com/mleroi/MMenu-Theme-for-WP-AppKit/blob/550b57ec094e78721ee6d76e8f6fc2a8c2b8d8f1/js/functions.js#L21

Hope it helps,
Happy app coding, 
and for any further questions don't hesitate to use our support via http://uncategorized-creations.com/contact/
